### PR TITLE
unicode was removed in Python 3 because all str are Unicode

### DIFF
--- a/data/coco/PythonAPI/pycocotools/coco.py
+++ b/data/coco/PythonAPI/pycocotools/coco.py
@@ -55,12 +55,15 @@ import itertools
 from . import mask as maskUtils
 import os
 from collections import defaultdict
-import sys
-PYTHON_VERSION = sys.version_info[0]
-if PYTHON_VERSION == 2:
-    from urllib import urlretrieve
-elif PYTHON_VERSION == 3:
+try:
     from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 def _isArrayLike(obj):
@@ -305,7 +308,7 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or type(resFile) == unicode:
+        if isinstance(resFile, basestring):
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)


### PR DESCRIPTION
Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).